### PR TITLE
fix: encode non-ascii characters in locations for Python 2

### DIFF
--- a/sopel_modules/weather/weather.py
+++ b/sopel_modules/weather/weather.py
@@ -40,13 +40,13 @@ def search(mode, query, api_key):
     results = None
 
     # Check if it's a WOEID
-    if re.match(r'^w[0-9]+$', str(query)):
+    if re.match(r'^w[0-9]+$', query.encode('utf-8').decode('utf-8')):
         # Strip off the w from WOEID
         results = requests.get(
             'https://api.openweathermap.org/data/2.5/%s?id=%s&appid=%s&units=metric' % (mode, query[1:], api_key))
     # Check if zip code (this doesn't cover all, but most)
     # https://en.wikipedia.org/wiki/List_of_postal_codes
-    elif re.match(r'^\d+$', str(query)):
+    elif re.match(r'^\d+$', query.encode('utf-8').decode('utf-8')):
         results = requests.get(
             'https://api.openweathermap.org/data/2.5/%s?zip=%s&appid=%s&units=metric' % (mode, query, api_key))
     # Otherwise, we assume it's a city name or location


### PR DESCRIPTION
Convert location query string to "utf-8" explicitly to prevent `UnicodeEncodeError: 'ascii' codec can't encode character`.

The other day a user in #sopel (around 2019-28-01T15:30Z) asked about the error mentioned above. The error arose from command `.weather järvenpää`, which clearly has non-ascii characters. Strings are quite different in Python 2 and 3. the `str` type is generally limited to ascii in Python 2, but in Python 3 is essentially the same as `unicode` from Python 2. The `.encode().decode()` chain in Python 2 trans-codes the string to `utf-8`, and happens to have no side effects in Python 3.