### PR TITLE
Add "we" alias

### DIFF
--- a/sopel_modules/weather/weather.py
+++ b/sopel_modules/weather/weather.py
@@ -207,7 +207,7 @@ def get_weather(bot, trigger):
         raise Exception('Error: Unsupported Provider')
 
 
-@commands('weather', 'wea')
+@commands('weather', 'wea', 'we')
 @example('.weather')
 @example('.weather London')
 @example('.weather Seattle, US')


### PR DESCRIPTION
"we" seems pretty available and unlikely to be taken by anything else (it's also a common weather alias), so added an alias for it as well.