### PR TITLE
openmeteo: switch from `current_weather` to `current` parameter

### DIFF
--- a/sopel_modules/weather/providers/weather/openmeteo.py
+++ b/sopel_modules/weather/providers/weather/openmeteo.py
@@ -79,10 +79,10 @@ def openmeteo_weather(bot, latitude, longitude, location):
     params = {
         'latitude': latitude,
         'longitude': longitude,
-        'current_weather': 1,
-        'windspeed_unit': 'ms',
-        'hourly': 'relativehumidity_2m',
+        'current': 'temperature_2m,relative_humidity_2m,precipitation,weather_code,wind_speed_10m,wind_direction_10m',
+        'wind_speed_unit': 'ms',
         'daily': 'sunrise,sunset',
+        'forecast_days': 1,
         'timeformat': 'unixtime',
         'timezone': 'auto',
     }
@@ -96,20 +96,17 @@ def openmeteo_weather(bot, latitude, longitude, location):
     if r.status_code != 200 or data.get('error') == 'true':
         raise Exception('Error: {}'.format(data['reason']))
 
-    condition = data['current_weather']['weathercode']
+    condition = data['current']['weather_code']
     condition = WEATHERCODE_MAP.get(condition, 'WMO code {}'.format(condition))
-
-    current_time_index = data['hourly']['time'].index(data['current_weather']['time'])
-    humidity = data['hourly']['relativehumidity_2m'][current_time_index]
 
     weather_data = {
         'location': location,
-        'temp': data['current_weather']['temperature'],
+        'temp': data['current']['temperature_2m'],
         'condition': condition,
-        'humidity': float(humidity / 100),  # Normalize to decimal percentage
+        'humidity': data['current']['relative_humidity_2m'] / 100.0,  # normalize to decimal percentage
         'wind': {
-            'speed': data['current_weather']['windspeed'],
-            'bearing': data['current_weather']['winddirection'],
+            'speed': data['current']['wind_speed_10m'],
+            'bearing': data['current']['wind_direction_10m'],
         },
         'timezone': data['timezone'],
     }

--- a/sopel_modules/weather/weather.py
+++ b/sopel_modules/weather/weather.py
@@ -13,7 +13,7 @@ import pytz
 
 from sopel.config.types import NO_DEFAULT, BooleanAttribute, ChoiceAttribute, StaticSection, ValidatedAttribute
 from sopel.plugin import commands, example, NOLIMIT
-from sopel.tools import Identifier
+from sopel.tools import get_logger, Identifier
 from sopel.tools.time import format_time
 
 from .providers.weather.openmeteo import openmeteo_forecast, openmeteo_weather
@@ -33,6 +33,8 @@ GEOCOORDS_PROVIDERS = {
     # for backward compatibility with previous `geocoords_provider` default value
     'locationiq': 'https://us1.locationiq.com/v1/search.php',
 }
+
+LOGGER = get_logger('weather')
 
 
 # Define our sopel weather configuration
@@ -300,6 +302,7 @@ def weather_command(bot, trigger):
         data = get_weather(bot, trigger)
     except Exception as err:
         bot.reply("Could not get weather: " + str(err))
+        LOGGER.debug('Error in weather provider.', exc_info=err)
         return
 
     weather = u'{location}: {temp}, {condition}, {humidity}'.format(


### PR DESCRIPTION
The `current_weather=1` parameter no longer appears in Open-Meteo documentation, and is likely deprecated.

Handling that response format also presented us with intermittent bugs, especially around fetching humidity data from an hourly series based on timestamp data that wasn't necessarily aligned with that series.

Using the 'current' parameter, we can directly request exactly the weather properties we need, and nothing else.

Fixes #50.